### PR TITLE
Fix S3 backup SignatureDoesNotMatch for nested keys

### DIFF
--- a/internal/backups/s3.go
+++ b/internal/backups/s3.go
@@ -46,7 +46,18 @@ func newS3(cfg S3Config) *s3Client {
 }
 
 func (c *s3Client) objectURL(key string) string {
-	return strings.TrimSuffix(c.cfg.Endpoint, "/") + "/" + c.cfg.Bucket + "/" + url.PathEscape(c.cfg.KeyPrefix+key)
+	return strings.TrimSuffix(c.cfg.Endpoint, "/") + "/" + c.cfg.Bucket + "/" + escapeS3Key(c.cfg.KeyPrefix+key)
+}
+
+// escapeS3Key encodes each path segment individually so that the / separators
+// are preserved. url.PathEscape encodes the slash itself, which breaks SigV4
+// signing against S3-compatible backends.
+func escapeS3Key(key string) string {
+	escaped := strings.Split(key, "/")
+	for i, part := range escaped {
+		escaped[i] = url.PathEscape(part)
+	}
+	return strings.Join(escaped, "/")
 }
 
 // PutFile uploads a local file.

--- a/internal/backups/s3_test.go
+++ b/internal/backups/s3_test.go
@@ -28,7 +28,7 @@ func TestDeleteObjectSignsAndDeletesRequestedKey(t *testing.T) {
 	if method != http.MethodDelete {
 		t.Fatalf("method = %q, want DELETE", method)
 	}
-	if path != "/backups/windlass%2Fproject%2Farchive%20name.tar.gz" {
+	if path != "/backups/windlass/project/archive%20name.tar.gz" {
 		t.Fatalf("escaped path = %q", path)
 	}
 	if !strings.HasPrefix(authorization, "AWS4-HMAC-SHA256 Credential=access/") {


### PR DESCRIPTION
## Summary

- preserve `/` separators when escaping S3 object-key path segments
- keep spaces and other segment characters safely URL-escaped
- update the existing delete-path test to cover nested keys

## Root cause

`url.PathEscape` was applied to the complete key, converting separators to `%2F`. The request path used for AWS Signature V4 then disagreed with S3-compatible backends' canonical path, causing `SignatureDoesNotMatch` for keys containing directories.

The new helper escapes each segment individually and joins the segments with `/`.

## Verification

- `git diff --check` passes.
- The existing `TestDeleteObjectSignsAndDeletesRequestedKey` now verifies preserved separators and encoded spaces.
- I could not run `go test` in my environment because the Go toolchain is not installed. Please run the repository's Go test suite in CI.

Fixes #13