### PR TITLE
Wait for the Docker proxy port instead of sleeping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,7 +166,11 @@ jobs:
           sudo sh install/install.sh --yes --no-caddy --binary bin/windlass-linux-amd64
       - name: Verify service and first-run flow
         run: |
-          sleep 2
+          # The proxy unit pulls its image on first start, so the port is not
+          # up the instant systemd calls the unit active. Wait for the API to
+          # answer instead of sleeping a fixed 2 seconds.
+          timeout 120 sh -c 'until curl -fsS -o /dev/null http://127.0.0.1:2375/version; do sleep 1; done'
+          timeout 60 sh -c 'until curl -fsS -o /dev/null http://localhost:8080/api/v1/system/health; do sleep 1; done'
           sudo systemctl is-active windlass-docker-proxy
           sudo systemctl is-active windlass
           curl -fsS http://127.0.0.1:2375/version | grep -q ApiVersion

--- a/install/install.sh
+++ b/install/install.sh
@@ -176,7 +176,9 @@ Requires=docker.service
 [Service]
 Type=simple
 ExecStartPre=-/usr/bin/docker rm -f windlass-docker-proxy
+ExecStartPre=-/usr/bin/docker pull ghcr.io/tecnativa/docker-socket-proxy:v0.4.2
 ExecStart=/usr/bin/docker run --rm --name windlass-docker-proxy --cap-drop=ALL --security-opt=no-new-privileges -p 127.0.0.1:2375:2375 -v /var/run/docker.sock:/var/run/docker.sock:ro -e POST=1 -e BUILD=1 -e CONTAINERS=1 -e ALLOW_START=1 -e ALLOW_STOP=1 -e ALLOW_RESTARTS=1 -e EVENTS=1 -e EXEC=1 -e IMAGES=1 -e INFO=1 -e NETWORKS=1 -e SYSTEM=1 -e VERSION=1 -e VOLUMES=1 ghcr.io/tecnativa/docker-socket-proxy:v0.4.2
+ExecStartPost=/bin/sh -c 'timeout 90 sh -c "until /usr/bin/docker -H tcp://127.0.0.1:2375 version >/dev/null 2>&1; do sleep 1; done"'
 ExecStop=-/usr/bin/docker stop -t 10 windlass-docker-proxy
 Restart=always
 RestartSec=2


### PR DESCRIPTION
## The failure

`Installer smoke test` is a required check and has failed on every run on main since 11 August, intermittently before that. Nothing merges while it is red, including #14.

It is a race, not a broken installer. The proxy unit is `Type=simple` running `docker run ... ghcr.io/tecnativa/docker-socket-proxy`, so systemd reports it active as soon as the process forks, which is while the image is still being pulled. From the last failing run on main:

```
20:53:52.45  Created symlink ... windlass-docker-proxy.service   (systemctl enable --now)
20:53:55.19  systemctl is-active windlass-docker-proxy -> active
20:53:55.26  curl 127.0.0.1:2375 -> Failed to connect, connection refused
```

Under three seconds, against a cold GHCR pull. That is also why it passed sometimes in July.

## The change

- `ExecStartPre=-/usr/bin/docker pull ...` so the pull is not racing the port.
- `ExecStartPost` holds the unit in activating until the Docker API answers, so `windlass.service`, ordered after it, starts against a working proxy instead of one that has merely forked.
- CI waits for the port and the panel health endpoint rather than sleeping 2 seconds.

The probe uses the docker CLI that `ExecStart` already requires, so it adds no dependency.

## Verification

- Ran a real `docker-socket-proxy` container with the same flags: the probe exits 0 once the API answers, and 124 on timeout against a dead port, so it fails rather than hanging.
- `systemd-analyze verify` accepts the generated unit, and `sh -n install/install.sh` parses.
- The proof that matters is this PR's own `Installer smoke test` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fQ4rbJo9X6nDCjNdU2T5