### PR TITLE
Build the container image from the cross-compiled binary

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -70,6 +70,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Only the runtime stage's apk install needs emulation now.
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
       - name: Build and push image
         uses: docker/build-push-action@v7
@@ -79,6 +81,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ env.VERSION }}
+            BINARY_STAGE=prebuilt
           tags: |
             ghcr.io/sulaiman-dauda/windlass:latest
             ghcr.io/sulaiman-dauda/windlass:${{ env.VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Only the runtime stage's apk install needs emulation now.
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
       - name: Build and push image
         uses: docker/build-push-action@v7
@@ -61,6 +63,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ github.ref_name }}
+            BINARY_STAGE=prebuilt
           tags: |
             ghcr.io/sulaiman-dauda/windlass:latest
             ghcr.io/sulaiman-dauda/windlass:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
 # Windlass container image. The panel needs the docker CLI (+ compose
 # plugin) and git; the host's Docker socket is mounted at runtime.
 #
-#   docker build -t windlass .
+#   docker build -t windlass .                     builds from source
+#   docker build -t windlass --build-arg BINARY_STAGE=prebuilt .
+#                                                  uses dist/windlass-linux-$TARGETARCH
 #   see install/docker-compose.install.yaml for running it
+#
+# The release workflows cross-compile both architectures natively and then
+# select the prebuilt stage, so nothing but a small apk install runs under
+# emulation. Compiling Go and npm under QEMU for arm64 ran past the six hour
+# job ceiling and was cancelled every time, which is why no image was ever
+# published.
+
+# Declared before the first FROM so it can be used in one.
+ARG BINARY_STAGE=build
 
 FROM node:22-alpine AS web
 WORKDIR /src/web
@@ -22,9 +33,19 @@ RUN CGO_ENABLED=0 go build -trimpath -tags embedweb \
     -ldflags "-s -w -X github.com/windlass-dev/windlass/internal/version.Version=${VERSION}" \
     -o /windlass ./cmd/windlass
 
+# Prebuilt: the caller cross-compiled into dist/ already. TARGETARCH is set by
+# buildx once per platform in the manifest list, and matches the file names the
+# release workflows write.
+FROM alpine:3.21 AS prebuilt
+ARG TARGETARCH
+COPY --chmod=0755 dist/windlass-linux-${TARGETARCH} /windlass
+
+# Whichever of the two stages above supplied the binary.
+FROM ${BINARY_STAGE} AS binary
+
 FROM alpine:3.21
 RUN apk add --no-cache docker-cli docker-cli-compose git ca-certificates
-COPY --from=build /windlass /usr/local/bin/windlass
+COPY --from=binary /windlass /usr/local/bin/windlass
 ENV WINDLASS_DATA=/var/lib/windlass \
     WINDLASS_NO_SELF_UPDATE=1
 VOLUME /var/lib/windlass


### PR DESCRIPTION
## The image has never been published

`ghcr.io/sulaiman-dauda/windlass` does not exist as a package (`gh api user/packages/container/windlass` returns 404), so the Docker install path in `install/docker-compose.install.yaml`, which pulls `:latest`, has always pointed at nothing.

The Dockerfile compiles the frontend and the Go binary inside the image, and both release workflows ask buildx for `linux/amd64,linux/arm64`. The arm64 leg therefore runs npm and the Go toolchain under QEMU. That build hit the six hour job ceiling on 11 August and was cancelled; today's two runs were still sitting on the same step and holding the release queue behind them.

## The change

Both workflows already cross-compile both architectures natively a few steps earlier, so the image does not need to build anything:

- a `prebuilt` stage that copies `dist/windlass-linux-$TARGETARCH`
- `BINARY_STAGE=prebuilt` passed from both release workflows
- `docker/setup-qemu-action` so the one remaining emulated step, the runtime stage's `apk add`, is explicit rather than relying on whatever binfmt the runner happens to have

`docker build -t windlass .` still builds from source, unchanged. That path is what the Dockerfile header documents and it stays the default.

## Verification

Against the same binaries CI produces:

- amd64 image builds in **9.5s** (versus a six hour timeout), runs, and serves `/api/v1/system/health` as `{"status":"ok","version":"v0.0.0-local"}`. The version proves it is running the prebuilt binary rather than a rebuild.
- the panel returns 200, and the image carries docker 27.3.1, compose 2.31.0 and git 2.47.3
- the arm64 `prebuilt` stage copies the aarch64 ELF, 16711842 bytes, matching `dist/windlass-linux-arm64` exactly and distinct from the amd64 binary's 17735842

arm64's `apk` layer could not be exercised on my machine, which has no aarch64 binfmt handler. That is what `setup-qemu-action` covers, and this PR's own image build is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fQ4rbJo9X6nDCjNdU2T5