### PR TITLE
fix(backups): escape S3 keys with full SigV4 unreserved set

### DIFF
--- a/internal/backups/s3.go
+++ b/internal/backups/s3.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -49,15 +48,27 @@ func (c *s3Client) objectURL(key string) string {
 	return strings.TrimSuffix(c.cfg.Endpoint, "/") + "/" + c.cfg.Bucket + "/" + escapeS3Key(c.cfg.KeyPrefix+key)
 }
 
-// escapeS3Key encodes each path segment individually so that the / separators
-// are preserved. url.PathEscape encodes the slash itself, which breaks SigV4
-// signing against S3-compatible backends.
+// escapeS3Key percent-encodes an S3 object key for use in a request URL while
+// keeping "/" as a literal path separator. SigV4 canonicalisation requires every
+// byte outside A-Za-z0-9-_.~ to be percent-encoded; url.PathEscape leaves
+// sub-delims such as "&", "=", and "+" alone, which produces SignatureDoesNotMatch
+// against S3-compatible backends when those characters appear in a key (or key_prefix).
 func escapeS3Key(key string) string {
-	escaped := strings.Split(key, "/")
-	for i, part := range escaped {
-		escaped[i] = url.PathEscape(part)
+	var b strings.Builder
+	b.Grow(len(key) + 8)
+	for i := 0; i < len(key); i++ {
+		c := key[i]
+		switch {
+		case c == '/':
+			b.WriteByte(c)
+		case (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+			c == '-' || c == '_' || c == '.' || c == '~':
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
 	}
-	return strings.Join(escaped, "/")
+	return b.String()
 }
 
 // PutFile uploads a local file.

--- a/internal/backups/s3_test.go
+++ b/internal/backups/s3_test.go
@@ -51,3 +51,37 @@ func TestDeleteObjectPreservesRecordOnRemoteFailure(t *testing.T) {
 		t.Fatalf("error = %v, want remote status", err)
 	}
 }
+
+func TestEscapeS3Key(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"project/archive.tar.gz", "project/archive.tar.gz"},
+		{"project/archive name.tar.gz", "project/archive%20name.tar.gz"},
+		{"a&b/c=d/e,f.tar.gz", "a%26b/c%3Dd/e%2Cf.tar.gz"},
+		{"my+project/x.tar.gz", "my%2Bproject/x.tar.gz"},
+		{"team+eu/proj/x.tar.gz", "team%2Beu/proj/x.tar.gz"},
+		{"café/x.tar.gz", "caf%C3%A9/x.tar.gz"},
+		{"a~b_c-d.e/x", "a~b_c-d.e/x"},
+		{"", ""},
+		{"/", "/"},
+		{"//", "//"},
+	}
+	for _, tt := range tests {
+		if got := escapeS3Key(tt.in); got != tt.want {
+			t.Errorf("escapeS3Key(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestObjectURLEscapesSigV4SpecialChars(t *testing.T) {
+	client := newS3(S3Config{
+		Endpoint: "https://s3.example.com", Region: "test", Bucket: "backups",
+		AccessKey: "access", SecretKey: "secret", KeyPrefix: "team+eu/",
+	})
+	got := client.objectURL("proj/a&b=c.tar.gz")
+	want := "https://s3.example.com/backups/team%2Beu/proj/a%26b%3Dc.tar.gz"
+	if got != want {
+		t.Fatalf("objectURL = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace per-segment `url.PathEscape` in `escapeS3Key` with a SigV4-correct encoder that percent-encodes every byte outside `A-Za-z0-9-_.~`, while keeping `/` as a literal separator.
- Fixes `SignatureDoesNotMatch` for operator-supplied `key_prefix` / keys containing `&`, `=`, `+`, and other sub-delims that `url.PathEscape` leaves alone.

Fixes #16

## Test plan
- [x] `go test ./internal/backups/ -count=1` (includes new `TestEscapeS3Key` + `TestObjectURLEscapesSigV4SpecialChars`)
- [ ] Optional: MinIO PUT/GET/DELETE with a key containing `&`, `=`, and `+`