### PR TITLE
Publish install.sh with every release, and adopt get.windlass.run

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -62,7 +62,8 @@ jobs:
             --title "Windlass $VERSION" \
             --notes "Automated release from ${GITHUB_SHA::7}: $(git log -1 --pretty=%s)" \
             --latest \
-            dist/windlass-linux-amd64 dist/windlass-linux-arm64 dist/checksums.txt
+            dist/windlass-linux-amd64 dist/windlass-linux-arm64 dist/checksums.txt \
+            install/install.sh
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ services:
 ## Install
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Sulaiman-Dauda/windlass/main/install/install.sh | sudo sh
+curl -fsSL https://get.windlass.run | sudo sh
 ```
 
 Claim the instance using the one-time token in `journalctl -u windlass`, then open

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@
 Run on a Linux x86_64 or arm64 server:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Sulaiman-Dauda/windlass/main/install/install.sh | sudo sh
+curl -fsSL https://get.windlass.run | sudo sh
 ```
 
 The installer:

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Windlass installer — https://github.com/Sulaiman-Dauda/windlass
 #
-#   curl -fsSL https://get.windlass.sh | sh
+#   curl -fsSL https://get.windlass.run | sudo sh
 #
 # Flags:
 #   --yes            non-interactive (assume yes)


### PR DESCRIPTION
The installer's header told people to run `https://get.windlass.sh`, a domain that was never registered. Anyone who read the script before piping it to root — the people you most want — found a dead host. The domain is now **windlass.run**.

`get.windlass.run` redirects to `install.sh` in the latest release, which exposed a second problem: **`autorelease.yaml` does not publish it.** `release.yaml` attaches `install/install.sh`; autorelease does not, and every release since v0.24 came from autorelease, so none of them carry the installer at all. The two release paths now ship the same assets.

README and `docs/install.md` use the vanity URL, which is also what the new site puts in front of people.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fQ4rbJo9X6nDCjNdU2T5