### PR TITLE
Add the get.windlass.run worker

### DIFF
--- a/install/get-worker/worker.js
+++ b/install/get-worker/worker.js
@@ -1,0 +1,35 @@
+// get.windlass.run — the install script's vanity URL.
+//
+//   curl -fsSL https://get.windlass.run | sudo sh
+//
+// A 302 rather than a 301: the target moves with every release, and a
+// permanently cached redirect would pin whoever ran it first to whichever
+// release happened to be current that day.
+//
+// install.sh is published as a release asset, so the script someone pipes to
+// root is the one that shipped with those binaries rather than whatever is on
+// main at the time.
+const REPO = "Sulaiman-Dauda/windlass";
+const LATEST = `https://github.com/${REPO}/releases/latest/download/install.sh`;
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    // Pin a version: get.windlass.run/v0.31
+    const tag = url.pathname.replace(/^\/+|\/+$/g, "");
+    const target = /^v\d+\.\d+(\.\d+)?$/.test(tag)
+      ? `https://github.com/${REPO}/releases/download/${tag}/install.sh`
+      : LATEST;
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: target,
+        "Cache-Control": "no-store",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  },
+};

--- a/install/get-worker/wrangler.toml
+++ b/install/get-worker/wrangler.toml
@@ -1,0 +1,7 @@
+# The vanity install URL. Deployed to the personal Cloudflare account and routed
+# at get.windlass.run; the site itself is Cloudflare Pages on the apex.
+name = "windlass-get"
+main = "worker.js"
+compatibility_date = "2026-09-05"
+
+routes = [{ pattern = "get.windlass.run/*", zone_name = "windlass.run" }]


### PR DESCRIPTION
The vanity install URL's source, so the redirect that sends people a script they pipe to root is reviewable in the repository rather than living only in a dashboard.

302 rather than 301, because the target moves with every release and a cached permanent redirect would pin whoever ran it first. `get.windlass.run/v0.31` pins a version deliberately.

It redirects to `install.sh` **in the release**, not on main, so the script matches the binaries it installs. That asset exists as of #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fQ4rbJo9X6nDCjNdU2T5