### PR TITLE
Accept the quoted mem_limit that Compose actually emits

### DIFF
--- a/internal/agent/local/compose.go
+++ b/internal/agent/local/compose.go
@@ -151,7 +151,7 @@ type composeConfig struct {
 			Target int `json:"target"`
 		} `json:"ports"`
 		Labels   map[string]string `json:"labels"`
-		MemLimit int64             `json:"mem_limit"`
+		MemLimit byteValue         `json:"mem_limit"`
 		CPUs     numberValue       `json:"cpus"`
 	} `json:"services"`
 }
@@ -172,6 +172,33 @@ func (n *numberValue) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*n = numberValue(value)
+	return nil
+}
+
+// Compose emits mem_limit as a quoted byte count rather than a number, so it
+// needs the same tolerance as cpus. Without it every compose file that sets a
+// memory limit fails to parse and the deployment stops.
+type byteValue int64
+
+func (b *byteValue) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		text := strings.Trim(string(data), `"`)
+		if text == "" {
+			*b = 0
+			return nil
+		}
+		parsed, err := strconv.ParseInt(text, 10, 64)
+		if err != nil {
+			return err
+		}
+		*b = byteValue(parsed)
+		return nil
+	}
+	var value int64
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = byteValue(value)
 	return nil
 }
 
@@ -205,7 +232,7 @@ func (c composeLocal) Config(ctx context.Context, project string) (agent.Resolve
 			ports = append(ports, published.Target)
 		}
 		resolved.Services[name] = agent.ResolvedService{
-			Image: svc.Image, ContainerPorts: ports, MemoryLimit: svc.MemLimit, CPULimit: float64(svc.CPUs),
+			Image: svc.Image, ContainerPorts: ports, MemoryLimit: int64(svc.MemLimit), CPULimit: float64(svc.CPUs),
 			Build: len(svc.Build) > 0 && string(svc.Build) != "null",
 		}
 		if rawURL := strings.TrimSpace(svc.Labels["windlass.health.url"]); rawURL != "" {

--- a/internal/agent/local/compose_test.go
+++ b/internal/agent/local/compose_test.go
@@ -1,0 +1,39 @@
+package local
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Compose is inconsistent about which resource numbers it quotes: cpus comes
+// back as a JSON number and mem_limit as a string. Parsing has to accept both
+// shapes for either field, or a valid compose file fails to deploy.
+func TestComposeConfigAcceptsQuotedAndBareLimits(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		mem     int64
+		cpus    float64
+	}{
+		{"compose emits mem_limit quoted", `{"services":{"api":{"mem_limit":"268435456","cpus":0.5}}}`, 268435456, 0.5},
+		{"both bare", `{"services":{"api":{"mem_limit":268435456,"cpus":0.5}}}`, 268435456, 0.5},
+		{"both quoted", `{"services":{"api":{"mem_limit":"268435456","cpus":"0.5"}}}`, 268435456, 0.5},
+		{"limits absent", `{"services":{"api":{"image":"nginx"}}}`, 0, 0},
+		{"empty string", `{"services":{"api":{"mem_limit":""}}}`, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg composeConfig
+			if err := json.Unmarshal([]byte(tc.payload), &cfg); err != nil {
+				t.Fatalf("parse compose config: %v", err)
+			}
+			svc := cfg.Services["api"]
+			if got := int64(svc.MemLimit); got != tc.mem {
+				t.Errorf("mem_limit = %d, want %d", got, tc.mem)
+			}
+			if got := float64(svc.CPUs); got != tc.cpus {
+				t.Errorf("cpus = %v, want %v", got, tc.cpus)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #21.

`docker compose config --format json` is inconsistent about which resource numbers it quotes:

```
cpus:      0.5           (number)
mem_limit: '268435456'   (string)
```

`mem_limit` was declared `int64`, so the whole config parse failed and took the deployment with it:

```
parse compose config: json: cannot unmarshal string into Go struct field ... mem_limit of type int64
```

`cpus` already had a `numberValue` type accepting both shapes, with a comment saying "accept both so a valid compose file never fails panel parsing". `mem_limit` simply never got the same treatment.

## Why it matters

The project overview screen tells operators to use these exact keys:

> Resource limits come directly from `mem_limit` and `cpus` in compose.yaml.

So the documented way to cap memory made the project undeployable, and the error an operator saw was a Go type name.

## Verification

Isolated on a running panel by deploying one project twice, changing only the limit key:

| compose.yaml | before | after |
| --- | --- | --- |
| `cpus: 0.5` | succeeded | succeeded |
| `mem_limit: 256m` | **failed** | succeeded |

The test reverts to the previous `int64` field and fails with the identical production error message, so it is checking the real thing rather than restating the fix. It also covers bare numbers, both-quoted, absent limits, and an empty string.

`go test ./...` and `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fQ4rbJo9X6nDCjNdU2T5