### PR TITLE
Write the operator documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Windlass documentation
+
+A Compose control plane that does not own your containers.
+
+## Start here
+
+- [Getting started](./getting-started.md), install, claim, deploy and route a first
+  project on a real server
+- [Install](./install.md), the installation methods in detail
+
+## Using it
+
+- [Projects and Compose](./projects-and-compose.md), how project directories, `.env`,
+  limits and health labels work
+- [Deployments](./deployments.md), the state machine, health gating, rollback and Git
+  deployments
+- [Domains and HTTPS](./domains-and-https.md), Caddy routes, certificates, and exactly
+  what Windlass will and will not touch
+- [Backups and restore](./backups-and-restore.md), archives, database dumps, S3 and what a
+  restore does not do
+- [Users and access](./users-and-access.md), roles, TOTP, OAuth sign-in and the privilege
+  boundary
+
+## Reference
+
+- [Configuration](./configuration.md), every `WINDLASS_*` variable and its default
+- [API](./api.md), the versioned HTTP API the panel itself uses
+- [Architecture](./architecture.md), how it is put together and why it shells out to
+  `docker compose`
+- [Troubleshooting](./troubleshooting.md), the failures that are most often misread
+
+## The part that matters
+
+- [Life without the panel](./life-without-the-panel.md), what happens to your containers
+  if Windlass stops, is removed, or was never there

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,66 @@
+# API
+
+Windlass has a versioned HTTP API under `/api/v1`. The panel is a client of it: there is
+no private interface the UI uses and you cannot.
+
+The full specification is served by a running instance and lives in the repository:
+
+- `GET /api/v1/openapi.yaml` from your own panel
+- [`api/openapi.yaml`](https://github.com/Sulaiman-Dauda/windlass/blob/main/api/openapi.yaml)
+
+A test asserts the specification covers the routes that exist, so it does not drift away
+from the implementation the way a hand-maintained document would.
+
+## Authenticating
+
+Sign in and keep the session cookie:
+
+```sh
+curl -sS -c jar -X POST https://panel.example/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"you@example.com","password":"..."}'
+
+curl -sS -b jar https://panel.example/api/v1/projects
+```
+
+Sessions are server-side rows, so a session can be revoked. Accounts with TOTP complete
+the second factor before the session is usable.
+
+## Shape of it
+
+Sixty-six paths, grouped roughly as:
+
+| Group | Examples |
+| --- | --- |
+| Projects | `GET/POST /projects`, `GET/PUT /projects/{name}/files/{path}`, `GET/PUT /projects/{name}/env` |
+| Deployments | `GET/POST /projects/{name}/deployments`, `POST /projects/{name}/deployments/{number}/rollback` |
+| Domains | `GET/POST /projects/{name}/domains`, `DELETE /projects/{name}/domains/{hostname}` |
+| Backups | `GET/POST /projects/{name}/backups`, `POST /projects/{name}/backups/{id}/restore`, `GET/PUT /projects/{name}/backups/schedule` |
+| Runtime | `GET /projects/{name}/services`, `GET /projects/{name}/logs`, `GET /projects/{name}/terminal` |
+| Platform | `GET /system/metrics`, `GET/POST /system/update`, `GET /proxy/status`, `GET /events` |
+| Access | `GET/POST /users`, `PUT /users/{id}/role`, `POST /auth/totp/setup` |
+| Git | `GET/POST /git/connections`, `PUT /projects/{name}/git`, `POST /webhooks/{provider}/{project}` |
+| Templates | `GET /templates`, `POST /templates/{key}` |
+
+## Streaming
+
+Logs, deployment progress and platform events are Server-Sent Events. `GET /events` is the
+platform stream; `GET /projects/{name}/deployments/{number}/events` follows one deployment.
+
+An SSE connection stays open, which trips up tooling that waits for a request to finish.
+Consume it as a stream or ask for a bounded read.
+
+`GET /projects/{name}/terminal` is a WebSocket.
+
+## Rules that apply to every endpoint
+
+State-changing requests are checked against the caller's role and written to the audit
+log. The check is in the handler, so it applies equally to the panel, to `curl`, and to
+anything else holding a session.
+
+Rate limiting applies to authentication endpoints.
+
+## Health
+
+`GET /api/v1/system/health` needs no authentication and is the right target for an uptime
+check.

--- a/docs/backups-and-restore.md
+++ b/docs/backups-and-restore.md
@@ -1,0 +1,72 @@
+# Backups and restore
+
+A backup is a compressed archive of the project directory: `compose.yaml`, `.env`, and
+whatever else lives alongside them. For projects that look like one of the database
+templates, Windlass also runs a native dump into the project directory first, so the
+archive contains it.
+
+## Taking one
+
+**Back up now** in the project's Backups tab. Backups are listed with their status, and an
+incomplete one cannot be restored.
+
+The database dump is best effort and deliberately non-fatal. If the database container is
+not running, the dump is skipped with a warning and the file archive is still taken. A
+backup that captured your compose file and environment is worth having even on a day the
+database was down.
+
+Postgres projects are dumped with `pg_dump`, MySQL and MariaDB with `mysqldump
+--all-databases`, both executed inside the running container.
+
+## Scheduling
+
+Set an interval of hourly, daily or weekly, a destination, and how many to retain. Older
+backups beyond the retention count are removed as new ones succeed.
+
+Pick a retention that matches what the archives cost you: they contain your `.env`, so
+they are secrets at rest wherever they land.
+
+## Off-server storage with S3
+
+Configure an S3-compatible endpoint under Settings and choose S3 as a backup destination.
+Anything speaking the S3 API works, including MinIO, which is what the wire tests run
+against.
+
+Backups on a server are a hedge against a mistake. Backups off the server are a hedge
+against losing the server. If the data matters, use the second kind.
+
+## Restoring
+
+Restore replays the **project directory** from the archive: compose file, environment
+file, and the other files that were there, the database dump among them.
+
+**It does not load the dump back into your database.** Restoring gives you the dump file
+in the project directory; putting its contents back is a deliberate act you perform, with
+the database in the state you intend:
+
+```sh
+cd /var/lib/windlass/projects/shop-api
+docker compose up -d db
+docker compose exec -T db psql -U postgres < dump.sql
+```
+
+This is deliberate. A restore that replayed a dump automatically would overwrite whatever
+the database currently holds, with no way to inspect it first, so Windlass restores the
+files and leaves that step to you.
+
+## What is not in a project backup
+
+Platform state lives in SQLite: users, sessions, audit history, deployment history,
+settings and encrypted credentials. Project backups do not contain it.
+
+Restoring a project directory onto a fresh install gives you a working application, and
+**Scan stacks directory** indexes it. Your accounts and history need a platform backup,
+which is a copy of the data directory taken while the service is stopped:
+
+```sh
+sudo systemctl stop windlass
+sudo tar czf windlass-platform-$(date +%F).tar.gz -C /var/lib windlass
+sudo systemctl start windlass
+```
+
+Keep that archive somewhere other than the machine it came from.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,60 @@
+# Configuration reference
+
+Windlass is configured entirely through `WINDLASS_*` environment variables, so it behaves
+the same under systemd and under Docker. Everything else, the parts an operator changes
+day to day, lives in Settings in the panel.
+
+Under systemd, put overrides in a drop-in rather than editing the unit:
+
+```sh
+sudo systemctl edit windlass
+```
+
+```ini
+[Service]
+Environment=WINDLASS_LOG_LEVEL=debug
+```
+
+## Variables
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `WINDLASS_ADDR` | `:8080` | Listen address for the HTTP server. |
+| `WINDLASS_DATA` | `/var/lib/windlass` | Platform state: SQLite database, secret key, projects. |
+| `WINDLASS_PROJECTS` | `<data>/projects` | Where project directories live. Point it at an existing stacks directory to adopt what is already there. |
+| `WINDLASS_LOG_LEVEL` | `info` | One of `debug`, `info`, `warn`, `error`. An unrecognised value is a startup error rather than a silent fallback. |
+| `WINDLASS_CADDY_ADMIN` | `http://127.0.0.1:2019` | Caddy admin API. Set this when Caddy runs in a container: `http://caddy:2019`. |
+| `WINDLASS_PANEL_UPSTREAM` | `127.0.0.1:8080` | The address Caddy dials to reach the panel, used by the Settings-managed panel hostname. Change it when Caddy is not on the host network. |
+| `WINDLASS_TRUSTED_PROXIES` | `127.0.0.0/8,::1/128` | Sources allowed to supply forwarding headers. The default covers the recommended local Caddy. Widen it only for a proxy you control. |
+| `WINDLASS_UPDATE_REPO` | `Sulaiman-Dauda/windlass` | Repository checked for releases. |
+| `WINDLASS_UPDATE_TOKEN` | unset | Authenticates release checks and downloads. Required only for a private update repository. |
+| `WINDLASS_NO_SELF_UPDATE` | unset | Any non-empty value disables self-update. Useful when a package manager or image tag owns the version. |
+
+`WINDLASS_TRUSTED_PROXIES` decides whether a client-supplied `X-Forwarded-For` is believed.
+Trusting an address you do not control lets a client claim any source IP, which matters
+wherever an IP is used for a decision or an audit entry. The default trusts loopback only,
+which is right for Caddy on the same host.
+
+## Settings in the panel
+
+These are not environment variables, and they are stored in SQLite:
+
+- Panel hostname, which creates the HTTPS route for the panel itself
+- OAuth sign-in providers
+- GitHub App and Git connections
+- Container registry credentials
+- S3 backup endpoint and credentials
+- Update checking
+
+## Files on disk
+
+```text
+/var/lib/windlass/
+├── windlass.db      # platform state
+├── secret.key       # encryption key for stored credentials
+└── projects/        # one directory per project
+```
+
+`secret.key` decrypts stored credentials. A platform backup without it leaves those
+credentials unreadable, and a copy of it in the wrong place hands them over. Back the data
+directory up as a whole, and treat the archive as a secret.

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -1,0 +1,63 @@
+# Deployments
+
+A deployment is a resumable state machine, not a single `docker compose up`. It runs a
+fixed sequence and records every step:
+
+```text
+env render -> validate -> sync -> pull -> build -> up -> verify
+```
+
+The log streams to the Deployments tab as it goes, and is kept afterwards, so a
+deployment that failed last Tuesday still has its output.
+
+![The Deployments tab: numbered history down the left, streaming deployment log on the right](./screenshots/deployments-light.png)
+
+## The steps
+
+**env render** writes `.env` from stored values. **validate** runs `docker compose config`
+and refuses to continue if the file is invalid, so a typo fails before anything is
+stopped. **sync** fetches the Git revision when the project is Git-backed. **pull** and
+**build** fetch or build images. **up** hands over to `docker compose up -d`.
+
+**verify** is the step that separates a deployment from a command. Windlass waits for
+Docker healthchecks and any `windlass.health.*` labels to pass before reporting success. A
+stack that starts and immediately crash-loops is a failed deployment, not a green one, and
+the failure is recorded with its reason.
+
+## Interruptions
+
+If the panel restarts mid-deployment, the deployment resumes on startup. Jobs are reclaimed
+by their `running` status rather than being abandoned, so a server reboot at the wrong
+moment does not leave a project half-updated with nobody watching.
+
+## Rollback
+
+Every deployment is numbered and can be rolled back from the Deployments list. Rollback
+redeploys the previous known-good revision through the same state machine, verification
+included, so a rollback that would not come up healthy fails visibly rather than quietly
+leaving you worse off.
+
+## Git deployments
+
+Connect a repository in the project's Git tab, either by pasting a clone URL or through a
+GitHub connection. Windlass stores the repository, branch and auto-deploy preference in
+`.windlass.json`, in the project directory, next to the compose file.
+
+With auto-deploy on, a push triggers a deployment. The webhook is registered on the
+repository for you when the connection allows it, and its secret is shown once at creation.
+Windlass verifies the signature on every delivery, so an unsigned or wrongly signed
+request deploys nothing.
+
+Manual is the default. A project only auto-deploys because you asked it to.
+
+## Private registries
+
+Images from private registries need credentials, configured under Settings. A GitHub
+connection can mint a `ghcr.io` credential directly, which saves generating a token by
+hand for the common case.
+
+## What a deployment does not do
+
+It does not reconstruct your container specification. Windlass shells out to `docker
+compose`, so what runs is what your compose file says, interpreted by Compose itself.
+The panel is not a translation layer that can disagree with it.

--- a/docs/domains-and-https.md
+++ b/docs/domains-and-https.md
@@ -1,0 +1,47 @@
+# Domains and HTTPS
+
+Windlass drives Caddy. Add a hostname to a project, point DNS at the server, and a
+certificate arrives on the first request. There is no certificate paperwork and no renewal
+to remember.
+
+## Adding a domain
+
+![The Domains tab: a hostname, service and port form above an active route](./screenshots/domains-light.png)
+
+In the project's Domains tab, enter the hostname and choose the service and container port
+to route to. The route is live as soon as it is written; the certificate follows within a
+few seconds of the first request to that hostname.
+
+DNS must already point at the server. Let's Encrypt validates by connecting to the name,
+so a hostname that does not resolve, or resolves elsewhere, cannot be issued a
+certificate. This is the usual reason a new domain sits unhealthy: check the A record
+before suspecting the panel.
+
+## What Windlass touches, and what it does not
+
+This matters if Caddy also serves things you configured yourself.
+
+Windlass owns exactly three kinds of object in the Caddy configuration:
+`windlass_routes`, `windlass_panel_route`, and the `windlass_route_*` children of the
+first. It changes them with targeted operations addressed by `@id`.
+
+It never loads or replaces the whole Caddy configuration. Routes you wrote by hand are not
+read, not rewritten and not reordered by anything Windlass does. The integration suite
+includes a user-owned route and asserts it survives.
+
+## The panel's own hostname
+
+The panel starts on port 8080. Under Settings you can give it a hostname, and Windlass
+adds `windlass_panel_route` so the panel is served over HTTPS on that name.
+
+Do this before exposing the panel to the internet. A control plane on plain HTTP over the
+public network is worth avoiding even behind a password.
+
+When Caddy is not on the host network, `WINDLASS_PANEL_UPSTREAM` sets the dial target
+Caddy should use to reach the panel. See the [configuration reference](./configuration.md).
+
+## If Windlass stops
+
+Caddy keeps serving every route it already has, including yours. Certificates continue to
+renew, because Caddy renews them, not Windlass. What stops is the ability to add or change
+routes from the panel until it is running again.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,111 @@
+# Getting started
+
+This walks through a first deployment on a fresh server: install Windlass, claim the
+instance, create a project, put a real domain in front of it, and confirm the container
+survives without the panel.
+
+Budget about fifteen minutes, most of it waiting for image pulls.
+
+## Before you start
+
+You need a Linux server with a public IP, root or sudo, and Docker installed. Windlass
+does not install Docker for you, and it will tell you so rather than guessing.
+
+If you want HTTPS on a real hostname, point an A record at the server now. DNS
+propagation is usually the slowest part of this page, so starting it first saves waiting
+later.
+
+## 1. Install
+
+```sh
+curl -fsSL https://get.windlass.run | sudo sh
+```
+
+The installer creates an unprivileged `windlass` user, installs a systemd unit, and puts
+a restricted Docker socket proxy in front of the daemon. Windlass reaches Docker through
+that proxy on loopback and is never added to the `docker` group, so a panel compromise
+does not hand over the daemon.
+
+When it finishes it prints the URL to open, which is the server's IP on port 8080.
+
+## 2. Claim the instance
+
+![The Windlass dashboard, showing host CPU, memory and disk above the project list](./screenshots/dashboard-light.png)
+
+Open that URL. The first visit asks you to create the first account, and only the first
+visit: once an account exists the setup route stops responding, so an instance cannot be
+claimed twice by whoever finds it next.
+
+Choose a real password. This account is an administrator on a machine that runs
+containers as root.
+
+Turn on TOTP straight away under Settings if the panel will be reachable from the
+internet. See [Users and access](./users-and-access.md).
+
+## 3. Create a project
+
+A project is a directory on the server holding a `compose.yaml`, an optional `.env`, and
+whatever else your stack needs. Nothing about it is Windlass-specific.
+
+Create one from **Projects, New project**. You get a starter compose file serving nginx,
+which is enough to prove the path end to end before you put your own stack in.
+
+Or start from **Templates** for something ready to run: Ghost, Gitea, PostgreSQL, Redis,
+MinIO, n8n and others. A template becomes an ordinary Compose project with generated
+credentials in its Environment tab. There is no proprietary layer to migrate off later.
+
+## 4. Deploy it
+
+Open the project, go to **Deployments**, press **Deploy**.
+
+A deployment runs a fixed sequence, and the log streams as it goes:
+
+```
+env render -> validate -> sync -> pull -> build -> up -> verify
+```
+
+The last step matters. Windlass waits for Docker healthchecks to report healthy, and for
+any `windlass.health.*` labels you set, before calling a deployment succeeded. A stack
+that starts and immediately crash-loops is reported as failed rather than green.
+
+If the panel restarts mid-deployment, the deployment resumes on startup rather than
+leaving the project half-updated.
+
+## 5. Put a domain in front of it
+
+In the project's **Domains** tab, add your hostname and pick the service and port to
+route to.
+
+Windlass writes a route into Caddy, which obtains a certificate from Let's Encrypt on
+first request. There is no certificate paperwork to do and no renewal to remember.
+
+Windlass only ever touches its own Caddy objects, by ID. Routes you wrote by hand are
+left exactly as they are. See [Domains and HTTPS](./domains-and-https.md).
+
+## 6. Prove it does not depend on the panel
+
+Worth doing once on your own server, because it is the claim everything else rests on:
+
+```sh
+sudo systemctl stop windlass
+curl -I https://your-domain.example
+```
+
+Your site still answers. The containers are ordinary Compose containers with a restart
+policy, started by `docker compose`, and Docker keeps them running. Caddy keeps serving
+the routes already in its configuration.
+
+```sh
+sudo systemctl start windlass
+```
+
+[Life without the panel](./life-without-the-panel.md) covers the full story, including
+how to run the same stacks by hand if you remove Windlass entirely.
+
+## Where to go next
+
+- [Projects and Compose](./projects-and-compose.md), how project directories and `.env` work
+- [Deployments](./deployments.md), the state machine, health gating and rollback
+- [Backups and restore](./backups-and-restore.md), archives, S3 and schedules
+- [Configuration reference](./configuration.md), every `WINDLASS_*` variable
+- [Troubleshooting](./troubleshooting.md), when a deployment or certificate misbehaves

--- a/docs/projects-and-compose.md
+++ b/docs/projects-and-compose.md
@@ -1,0 +1,108 @@
+# Projects and Compose
+
+A project is a directory. That is the whole idea, and most of what is surprising about
+Windlass follows from it.
+
+```text
+<projects>/<name>/
+├── compose.yaml       # services, images, ports, volumes, networks, limits
+├── .env               # optional dotenv file, mode 0600
+└── .windlass.json     # source repository, branch, auto-deploy, domains
+```
+
+The default projects directory is `/var/lib/windlass/projects`, which you can move with
+`WINDLASS_PROJECTS`. See the [configuration reference](./configuration.md).
+
+![A project overview: services with state, health, image and resource limits](./screenshots/project-light.png)
+
+## The filesystem wins
+
+Windlass runs the real `docker compose` CLI in that directory. It does not parse your
+compose file into an internal model and regenerate it, so nothing is lost in translation:
+no unsupported key silently dropped, no reformatting of a file you carefully commented.
+
+Which means editing over SSH is a supported workflow, not a workaround:
+
+```sh
+cd /var/lib/windlass/projects/shop-api
+vim compose.yaml
+docker compose up -d
+```
+
+The panel's Files and Environment screens read the same bytes. If you change a file on
+disk, the panel shows your change; if you change it in the panel, the file on disk
+changes. There is no sync step and no conflict resolution, because there is only one copy.
+
+SQLite holds platform state (users, sessions, audit entries, deployment history) and a
+rebuildable index of projects and domains. It is not a second copy of your configuration.
+Delete the database and your containers keep running; **Scan stacks directory** rebuilds
+the index from the filesystem.
+
+## Adopting stacks you already have
+
+If the server already runs Compose projects, move or symlink their directories under the
+projects directory and use **Scan stacks directory**. Windlass indexes what it finds,
+including containers already running, without redeploying anything.
+
+This is also the recovery path after restoring a machine from a backup: put the
+directories back, scan, and the panel knows about them again.
+
+## The environment file
+
+`.env` is a standard dotenv file, one `KEY=value` per line, written mode 0600. Compose
+substitutes it into `compose.yaml` the way it always does.
+
+The Environment tab edits the whole file at once rather than key by key. Pasting a block
+replaces the file wholesale, including removing keys that are not in what you pasted,
+which is the behaviour that matches what you see on screen.
+
+Values are visible to anyone who can read the file on the server and to anyone with panel
+access at member level or above. Treat it as what it is: a secrets file on a host.
+
+## Resource limits
+
+Limits come from the Compose keys, not from a panel setting:
+
+```yaml
+services:
+  api:
+    image: nginx:alpine
+    mem_limit: 256m
+    cpus: 0.5
+```
+
+The project overview shows what each service is actually limited to. Note that
+`deploy.resources.limits` is a Swarm key: Compose ignores it outside Swarm, so a service
+configured that way runs unlimited, and the overview will correctly say so.
+
+## Application health
+
+Docker healthchecks are honoured. Beyond those, three labels let a deployment wait for
+your application rather than for the container process:
+
+```yaml
+services:
+  api:
+    labels:
+      windlass.health.url: http://127.0.0.1:8081/
+      windlass.health.status: "200"
+      windlass.health.contains: "ok"
+```
+
+A deployment is only reported succeeded once these pass. See
+[Deployments](./deployments.md) for how that fits into the sequence.
+
+## Templates
+
+![The Templates screen: one-click apps and databases](./screenshots/templates-light.png)
+
+Templates create ordinary projects. A template writes a normal `compose.yaml` and a normal
+`.env` with generated credentials, then gets out of the way. The generated file even says
+so at the top:
+
+```text
+# This is a plain compose project. Edit it like any other.
+```
+
+There is no template runtime, no upgrade channel, and nothing that breaks if you rewrite
+the file the day after creating it.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,99 @@
+# Troubleshooting
+
+Where to look first, and the failures that are most often misread.
+
+## Reading the logs
+
+![The Logs tab, streaming container output](./screenshots/logs-light.png)
+
+```sh
+sudo journalctl -u windlass -f
+sudo journalctl -u windlass -n 200 --no-pager
+```
+
+For a deployment, the panel's own log is more useful than the service log: every step is
+recorded and kept, including for deployments that failed.
+
+## A deployment fails at validate
+
+`docker compose config` rejected the file. The message is Compose's own, and it is usually
+literal about the line. Nothing was stopped, because validation runs before anything is
+changed.
+
+Reproduce it directly on the server for the full context:
+
+```sh
+cd /var/lib/windlass/projects/<name>
+docker compose config
+```
+
+## A deployment fails at verify
+
+The containers started but did not become healthy. The application is the suspect, not the
+panel. Check what the container is saying:
+
+```sh
+docker compose logs --tail=100
+```
+
+A crash-loop, a database that was not ready, or a `windlass.health.url` pointing somewhere
+the container cannot reach are the common three. From inside a container, `127.0.0.1` is
+that container, not the host: use the host's Docker bridge address (commonly
+`172.17.0.1`) for a health URL that leaves the container.
+
+## A domain has no certificate
+
+Nearly always DNS. Let's Encrypt validates by connecting to the hostname, so it must
+resolve to this server before a certificate can be issued.
+
+```sh
+dig +short your-domain.example
+curl -I http://your-domain.example
+```
+
+If the record is right and recent, give it a few minutes. Behind a proxy such as
+Cloudflare, an orange-clouded record means the challenge reaches the proxy rather than
+your server, which is its own configuration question.
+
+## The panel is unreachable but the sites are fine
+
+This is expected. The panel is one process. Your containers are ordinary Compose containers with a restart policy, and Caddy
+serves the routes it already has.
+
+```sh
+sudo systemctl status windlass
+sudo systemctl restart windlass
+```
+
+## Docker is not reachable
+
+The service talks to Docker through a restricted socket proxy on loopback, not through the
+Docker group. If the panel reports Docker unavailable, check the proxy first:
+
+```sh
+sudo systemctl status windlass-docker-proxy
+docker -H tcp://127.0.0.1:2375 version
+```
+
+The fix is to get the proxy healthy. Adding the `windlass` user to the `docker` group
+would appear to work and would hand full daemon access to the panel process, which is the
+boundary the proxy exists to keep.
+
+## The panel does not know about a project that exists
+
+Use **Scan stacks directory**. The SQLite index is rebuildable on purpose: it is derived
+from the filesystem, and the filesystem is authoritative.
+
+## Restoring after losing the database
+
+Containers keep running throughout. Put the project directories back under the projects
+directory, start Windlass, and scan. Accounts, audit and deployment history come from a
+platform backup, not from the project directories. See
+[Backups and restore](./backups-and-restore.md).
+
+## Reporting a bug
+
+Server OS and version, Docker and Compose versions (shown at the top of the dashboard),
+what you did, what happened, and the relevant log lines. The compose file, with secrets
+removed, usually answers the first three follow-up questions:
+[github.com/Sulaiman-Dauda/windlass/issues](https://github.com/Sulaiman-Dauda/windlass/issues).

--- a/docs/users-and-access.md
+++ b/docs/users-and-access.md
@@ -1,0 +1,60 @@
+# Users and access
+
+## Claiming an instance
+
+The first visit to a new install creates the first account. After that the setup route
+stops responding, so an instance cannot be claimed a second time by whoever reaches it
+next.
+
+Claim a new install immediately. Until the first account exists, anyone who reaches the
+panel can create it.
+
+## Roles
+
+Three roles, in increasing order:
+
+| Role | Can |
+| --- | --- |
+| `viewer` | Read projects, deployments, logs and metrics |
+| `member` | Everything a viewer can, plus deploy, edit files and environment, manage domains and backups |
+| `admin` | Everything a member can, plus manage users, settings, credentials and updates |
+
+Every state-changing request is checked against the role on the server and written to the
+audit log. The check is in the handler, not in whether the button was drawn, so a hidden
+control is not a permission and cannot be worked around by sending the request directly.
+
+Deleting a project requires re-entering your password, unless the account signs in only
+through OAuth.
+
+![The Settings screen, where accounts, sign-in and platform options are managed](./screenshots/settings-light.png)
+
+## Two-factor authentication
+
+TOTP is available to every account and set up from Settings: scan the QR code, confirm a
+code, done. It is standard RFC 6238, so any authenticator works.
+
+Turn it on for administrators on any panel reachable from the internet. It is not
+mandatory, because a single-operator install on a private network gains little from it.
+
+## Signing in with GitHub
+
+OAuth can be enabled for sign-in. It signs in **existing** users matched by verified
+email, and does not create accounts. Someone with a GitHub account and an email you have
+never added cannot get in by being first to the login page.
+
+Create the account in the panel first, then let that person sign in with OAuth.
+
+## Sessions
+
+Sessions are server-side rows with an opaque cookie, not self-contained tokens, so signing
+someone out actually ends their session rather than waiting for a token to expire.
+
+## Exposing the panel
+
+Give the panel a hostname under Settings so it is served over HTTPS rather than on
+`:8080`. See [Domains and HTTPS](./domains-and-https.md).
+
+Windlass reaches Docker through a restricted socket proxy on loopback, and its service
+user is deliberately not in the `docker` group. Membership of that group is equivalent to
+root, so the proxy is what keeps a compromise of the panel from becoming a compromise of
+the host. Adding the user to the group removes that separation.


### PR DESCRIPTION
Replaces #25, which carried #24's files into its diff after that PR was squash-merged. This branch is built directly on `main` and contains only the ten documentation files.

The published set was `install`, `architecture` and `life-without-the-panel`. About 1,900 words, for software that takes root on a server and runs other people's production stacks. Anyone past their first deploy had to read the source.

This adds nine pages and an index, roughly 3,800 words.

| Page | Covers |
| --- | --- |
| `getting-started` | Install to first routed domain on a real server |
| `projects-and-compose` | Directories, `.env`, limits, health labels, adopting existing stacks |
| `deployments` | The state machine, health gating, resume, rollback, Git and webhooks |
| `domains-and-https` | Caddy routes, certificates, exactly which objects Windlass owns |
| `backups-and-restore` | Archives, database dumps, S3, retention, platform backups |
| `users-and-access` | Roles, TOTP, OAuth, the Docker privilege boundary |
| `configuration` | Every `WINDLASS_*` variable with its real default |
| `api` | The versioned API, pointing at the spec the coverage test enforces |
| `troubleshooting` | The failures that get misread |

Seven screenshots from #24 are placed where the reader needs to recognise the screen. They are ordinary relative markdown images so they render on GitHub; the website pairs each with its dark capture.

## Written against the implementation

Reading the code rather than working from memory changed two things that would otherwise have been documented wrongly:

- **Restore replays project files and does not load a database dump back in.** The dump lands in the project directory; putting it back is a deliberate act. The page gives the commands and explains why that is the right default.
- **Roles are `viewer` / `member` / `admin`**, per `roleRank` in `internal/auth/middleware.go`.

`getting-started` ends by stopping the panel and curling the site, because that claim is the reason to choose this over the alternatives and a reader should verify it on their own server in the first fifteen minutes.

All internal links and image pairs resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fQ4rbJo9X6nDCjNdU2T5