### PR TITLE
Rebuild the website when documentation changes

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -10,6 +10,9 @@ on:
     paths:
       - "docs/**"
       - "README.md"
+  # So the build can be started by hand, to test the hook or to republish after
+  # a site-side change that this repository knows nothing about.
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,0 +1,34 @@
+# The website builds its guides by cloning this repository, so a documentation
+# change here is not live until the site rebuilds. Nothing connected the two,
+# and merged pages sat unpublished until someone pushed the site repository for
+# an unrelated reason.
+name: Publish docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "README.md"
+
+permissions: {}
+
+jobs:
+  rebuild-site:
+    name: Rebuild windlass.run
+    runs-on: ubuntu-latest
+    steps:
+      # A Cloudflare Pages deploy hook starts one build for the project it
+      # belongs to and can do nothing else, which makes it a far smaller thing
+      # to hold than an API token.
+      - name: Trigger the Pages build
+        env:
+          HOOK: ${{ secrets.PAGES_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "PAGES_DEPLOY_HOOK is not set; nothing to trigger."
+            exit 1
+          fi
+          code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$HOOK")
+          echo "Pages deploy hook returned $code"
+          [ "$code" = "200" ] || exit 1


### PR DESCRIPTION
windlass.run builds its guides by cloning this repository at build time, so documentation merged here is not live until the site rebuilds. Nothing connected the two.

The effect, found by checking the live site after merging the documentation rather than assuming it had shipped:

```
200  https://windlass.run/
404  https://windlass.run/guides/getting-started/
404  https://windlass.run/guides/troubleshooting/
```

Nine pages and sixteen screenshots were merged and unpublished. The site would have picked them up eventually, whenever the site repository was next pushed for an unrelated reason.

A push to `main` touching `docs/**` or `README.md` now calls a Cloudflare Pages deploy hook.

**Why a deploy hook rather than a token.** A deploy hook starts one build for one project and can do nothing else. An API token in a public repository's secrets is a far more valuable thing for an attacker to reach. The workflow declares `permissions: {}` because it needs none.

It exits non-zero when the secret is missing or the hook does not return 200, so a broken trigger shows up as a failed run rather than as a site that quietly stops updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fQ4rbJo9X6nDCjNdU2T5