### PR TITLE
Sign releases with build provenance

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -14,6 +14,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: autorelease
@@ -54,6 +56,23 @@ jobs:
         working-directory: dist
         run: sha256sum windlass-linux-* > checksums.txt
 
+
+      # A checksums file published in the same release as the binaries proves
+      # very little: whoever can write the release can rewrite both. This asks
+      # GitHub to sign a statement tying these exact bytes to this workflow and
+      # commit, stored outside the release where a release write cannot reach.
+      # It matters here more than most projects, because the documented install
+      # path is `curl -fsSL https://get.windlass.run | sudo sh`.
+      #
+      # Verify a download with:
+      #   gh attestation verify windlass-linux-amd64 --repo Sulaiman-Dauda/windlass
+      - name: Attest binary provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            dist/windlass-linux-amd64
+            dist/windlass-linux-arm64
+
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -75,6 +94,7 @@ jobs:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
       - name: Build and push image
+        id: image
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -86,3 +106,15 @@ jobs:
           tags: |
             ghcr.io/sulaiman-dauda/windlass:latest
             ghcr.io/sulaiman-dauda/windlass:${{ env.VERSION }}
+
+      # The image is a second distribution path and needs its own attestation,
+      # addressed by digest rather than by a mutable tag.
+      #
+      #   gh attestation verify oci://ghcr.io/sulaiman-dauda/windlass:latest \
+      #     --repo Sulaiman-Dauda/windlass
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ghcr.io/sulaiman-dauda/windlass
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -37,6 +39,23 @@ jobs:
         working-directory: dist
         run: sha256sum windlass-linux-* > checksums.txt
 
+
+      # A checksums file published in the same release as the binaries proves
+      # very little: whoever can write the release can rewrite both. This asks
+      # GitHub to sign a statement tying these exact bytes to this workflow and
+      # commit, stored outside the release where a release write cannot reach.
+      # It matters here more than most projects, because the documented install
+      # path is `curl -fsSL https://get.windlass.run | sudo sh`.
+      #
+      # Verify a download with:
+      #   gh attestation verify windlass-linux-amd64 --repo Sulaiman-Dauda/windlass
+      - name: Attest binary provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            dist/windlass-linux-amd64
+            dist/windlass-linux-arm64
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -56,6 +75,7 @@ jobs:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
       - name: Build and push image
+        id: image
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -67,3 +87,15 @@ jobs:
           tags: |
             ghcr.io/sulaiman-dauda/windlass:latest
             ghcr.io/sulaiman-dauda/windlass:${{ github.ref_name }}
+
+      # The image is a second distribution path and needs its own attestation,
+      # addressed by digest rather than by a mutable tag.
+      #
+      #   gh attestation verify oci://ghcr.io/sulaiman-dauda/windlass:latest \
+      #     --repo Sulaiman-Dauda/windlass
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ghcr.io/sulaiman-dauda/windlass
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,6 +21,41 @@ The installer:
 Supported flags are `--yes`, `--version vX.Y.Z`, `--no-caddy`, `--no-docker`, and
 `--binary PATH` (local/CI installation).
 
+## Verifying what you are about to run
+
+The install command pipes a script from the internet into `sudo sh`, so it is reasonable
+to want to look first. The script is short and plain:
+
+```sh
+curl -fsSL https://get.windlass.run -o install.sh
+less install.sh
+sudo sh install.sh
+```
+
+Every release is also signed with GitHub build provenance, which ties those exact bytes
+to the workflow and commit that produced them. This is worth more than the published
+checksums on their own: `checksums.txt` ships in the same release as the binaries, so
+anyone able to rewrite one could rewrite the other. The attestation is stored outside the
+release, where a release write cannot reach it.
+
+To check a binary before installing it:
+
+```sh
+gh release download v0.37 --pattern 'windlass-linux-amd64'
+gh attestation verify windlass-linux-amd64 --repo Sulaiman-Dauda/windlass
+```
+
+And the container image, addressed by digest rather than by a tag that can move:
+
+```sh
+gh attestation verify oci://ghcr.io/sulaiman-dauda/windlass:latest \
+  --repo Sulaiman-Dauda/windlass
+```
+
+Verification is silent on success and exits 0, so check the exit code rather than looking
+for output. A binary that has been altered by even one byte fails with a lookup error for
+its digest.
+
 ## First run and panel HTTPS
 
 The default service listens on port 8080. Claim it using the one-time token printed in the


### PR DESCRIPTION
Releases ship `checksums.txt` and nothing else. A checksums file published in the same release as the binaries proves very little: whoever can write the release can rewrite both. That matters here more than most projects, because the documented install path is `curl -fsSL https://get.windlass.run | sudo sh`, run as root.

Both release paths now call `actions/attest-build-provenance`. GitHub signs a statement tying those exact bytes to the workflow and commit that produced them, stored outside the release where a release write cannot reach it.

## Details worth noting

- **Binaries are attested before the release is created**, so an attestation failure means no release rather than an unsigned one.
- **The image is attested separately**, after its push and addressed by `subject-digest` rather than by a tag that can move.
- **The action is pinned to a commit SHA** with the version in a trailing comment, the form Dependabot understands and updates. A tag is mutable, and whoever controls it controls the release pipeline.
- `id-token: write` and `attestations: write` added; nothing else was widened.

## For users

`docs/install.md` gains a section on reading the installer before running it and verifying a download:

```sh
gh attestation verify windlass-linux-amd64 --repo Sulaiman-Dauda/windlass
gh attestation verify oci://ghcr.io/sulaiman-dauda/windlass:latest --repo Sulaiman-Dauda/windlass
```

It notes that verification is silent on success, so the exit code is what to check rather than the output.

## Verification

Both workflows parse and the step order is right: attest, then create the release; push the image, then attest it. The attestations themselves can only be proved by cutting a release, so the real check is running `gh attestation verify` against the first release after this merges, and confirming a tampered copy fails. I will do that rather than assume it worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6fQ4rbJo9X6nDCjNdU2T5